### PR TITLE
Display SVG logos instead of the eduroam logo (Issue: #10).

### DIFF
--- a/WpfApp/Classes/ImageFunctions.cs
+++ b/WpfApp/Classes/ImageFunctions.cs
@@ -79,17 +79,20 @@ namespace WpfApp
         public static string GenerateSvgLogoHtml(byte[] logo, int maxWidth, int maxHeight)
         {
             string base64 = System.Convert.ToBase64String(logo);
-            return 
+            return
                 "<!DOCTYPE html>" +
                     "<html>" +
                         "<head>" +
                             "<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">" +
                             "<style>" +
+                                "html,body {" +
+                                    "margin: 2.5px 0 0 0;" +
+                                    "padding: 0;" +
+                                    "overflow: hidden;" +
+                                    "display: flex;" +
+                                    "justify-content: center;" +
+                                "}" +
                                 "img {" +
-                                    "position: absolute;" +
-                                    "top: 0;" +
-                                    "left: 0;" +
-                                    "display: block;" +
                                     "max-width:" + maxWidth + "px;" +
                                     "max-height:" + maxHeight + "px;" +
                                     "width: auto;" +

--- a/WpfApp/MainWindow.xaml.cs
+++ b/WpfApp/MainWindow.xaml.cs
@@ -555,8 +555,8 @@ namespace WpfApp
                 {
                     imgEduroamLogo.Visibility = Visibility.Visible;
                     imgLogo.Visibility = Visibility.Hidden;
-                    //webLogo.NavigateToString(ImageFunctions.GenerateSvgLogoHtml(logoBytes, cWidth, cHeight));
-                    //webLogo.Visibility = Visibility.Visible;
+                    webLogo.NavigateToString(ImageFunctions.GenerateSvgLogoHtml(logoBytes, cWidth, cHeight));
+                    webLogo.Visibility = Visibility.Visible;
                 }
                 else // other filetypes (jpg, png etc.)
                 {

--- a/WpfApp/MainWindow.xaml.cs
+++ b/WpfApp/MainWindow.xaml.cs
@@ -533,7 +533,6 @@ namespace WpfApp
         /// <summary>
         /// Loads the logo form the curent eapconfig if it exists.
         /// Else display Eduroam logo.
-        /// SVG not currently supported
         /// </summary>
         public void LoadProviderLogo()
         {
@@ -550,7 +549,7 @@ namespace WpfApp
                 int cWidth = (int)webLogo.Width;
                 int cHeight = (int)webLogo.Height;
 
-                // TODO SVG not currently supported
+                // SVG
                 if (logoMimeType == "image/svg+xml")
                 {
                     imgEduroamLogo.Visibility = Visibility.Visible;


### PR DESCRIPTION
Hi,

I've adapted the GenerateSvgLogoHtml method to return a centered SVG in HTML. This is used to display SVG provider logos centered at the top of the screen on the main page.

Issue #10 