### PR TITLE
Failure to Configure Correctly with an Anonymous Outer ID

### DIFF
--- a/EduroamConfigure/EapConfig.cs
+++ b/EduroamConfigure/EapConfig.cs
@@ -751,6 +751,20 @@ namespace EduroamConfigure
 		}
 
 		/// <summary>
+		/// Determine if this EapConfig needs the anonymous ident to have the same realm as the username
+		/// This is not enforced, the realm is simply dropped if needed, but this variable can be used to warn the user if the anonymous ident is modified
+		/// </summary>
+		public string RequiredAnonymousIdentRealm
+		{
+			get => !String.IsNullOrEmpty(SupportedAuthenticationMethods.First().ClientOuterIdentity)
+				&& SupportedAuthenticationMethods.First().ClientOuterIdentity.Contains("@")
+				&& (SupportedAuthenticationMethods.First().EapType, SupportedAuthenticationMethods.First().InnerAuthType) == (EapType.PEAP, InnerAuthType.EAP_MSCHAPv2)
+				? SupportedAuthenticationMethods.First().ClientOuterIdentity.Substring(SupportedAuthenticationMethods.First().ClientOuterIdentity.IndexOf("@"))
+				: null
+				;
+		}
+
+		/// <summary>
 		/// Reads and adds the user certificate to be installed along with the wlan profile
 		/// </summary>
 		/// <param name="filePath">path to the certificate file in question. PKCS12</param>

--- a/EduroamConfigure/EapConfig.cs
+++ b/EduroamConfigure/EapConfig.cs
@@ -753,13 +753,16 @@ namespace EduroamConfigure
 		/// <summary>
 		/// Determine if this EapConfig needs the anonymous ident to have the same realm as the username
 		/// This is not enforced, the realm is simply dropped if needed, but this variable can be used to warn the user if the anonymous ident is modified
+		/// Empty string means the username is required to not have a realm, null means that no realm is required
 		/// </summary>
 		public string RequiredAnonymousIdentRealm
 		{
 			get => !String.IsNullOrEmpty(SupportedAuthenticationMethods.First().ClientOuterIdentity)
-				&& SupportedAuthenticationMethods.First().ClientOuterIdentity.Contains("@")
-				&& (SupportedAuthenticationMethods.First().EapType, SupportedAuthenticationMethods.First().InnerAuthType) == (EapType.PEAP, InnerAuthType.EAP_MSCHAPv2)
-				? SupportedAuthenticationMethods.First().ClientOuterIdentity.Substring(SupportedAuthenticationMethods.First().ClientOuterIdentity.IndexOf("@"))
+				&& SupportedAuthenticationMethods.First().EapType == EapType.PEAP
+				&& SupportedAuthenticationMethods.First().InnerAuthType == InnerAuthType.EAP_MSCHAPv2
+				? SupportedAuthenticationMethods.First().ClientOuterIdentity.Contains("@")
+					? SupportedAuthenticationMethods.First().ClientOuterIdentity.Substring(SupportedAuthenticationMethods.First().ClientOuterIdentity.IndexOf("@"))
+					: ""
 				: null
 				;
 		}

--- a/EduroamConfigure/ProfileXml.cs
+++ b/EduroamConfigure/ProfileXml.cs
@@ -378,7 +378,7 @@ namespace EduroamConfigure
 									CreateEapConfiguration(
 										eapType:EapType.MSCHAPv2,
 										innerAuthType: InnerAuthType.None,
-										outerIdentity: outerIdentity,
+										outerIdentity: null, // Not relevant for inner auth
 										// Strip server names and thumbprints from inner EAP, only need in outer
 										serverNames: new List<string>(),
 										caThumbprints: new List<string>()

--- a/EduroamConfigure/ProfileXml.cs
+++ b/EduroamConfigure/ProfileXml.cs
@@ -280,7 +280,7 @@ namespace EduroamConfigure
 				// Windows wants to add the realm itself, we must only set the local part
 				// This appears to be the case for PEAP-EAP-MSCHAPv2
 				string anonymousUserName = outerIdentity.Contains("@")
-					? outerIdentity.Substring(outerIdentity.IndexOf("@"))
+					? outerIdentity.Substring(0, outerIdentity.IndexOf("@"))
 					: outerIdentity
 					;
 

--- a/EduroamConfigure/ProfileXml.cs
+++ b/EduroamConfigure/ProfileXml.cs
@@ -277,6 +277,13 @@ namespace EduroamConfigure
 				nsEapType = nsMPCPv1;
 				thumbprintNodeName = "TrustedRootCA";
 
+				// Windows wants to add the realm itself, we must only set the local part
+				// This appears to be the case for PEAP-EAP-MSCHAPv2
+				string anonymousUserName = outerIdentity.Contains("@")
+					? outerIdentity.Substring(outerIdentity.IndexOf("@"))
+					: outerIdentity
+					;
+
 				// adds MSCHAPv2 specific elements (inner eap)
 				configElement.Add(
 					new XElement(nsBECP + "Eap", // PEAP
@@ -300,13 +307,13 @@ namespace EduroamConfigure
 							new XElement(nsMPCPv1 + "PeapExtensions",
 								new XElement(nsMPCPv2 + "PerformServerValidation", "true"),
 								new XElement(nsMPCPv2 + "AcceptServerName", "true"),
-								String.IsNullOrWhiteSpace(outerIdentity)
+								String.IsNullOrWhiteSpace(anonymousUserName)
 									? new XElement(nsMPCPv2 + "IdentityPrivacy",
 										new XElement(nsMPCPv2 + "EnableIdentityPrivacy", "false")
 									)
 									: new XElement(nsMPCPv2 + "IdentityPrivacy",
 										new XElement(nsMPCPv2 + "EnableIdentityPrivacy", "true"),
-										new XElement(nsMPCPv2 + "AnonymousUserName", outerIdentity)
+										new XElement(nsMPCPv2 + "AnonymousUserName", anonymousUserName)
 									)
 								,
 

--- a/EduroamConfigure/ProfileXml.cs
+++ b/EduroamConfigure/ProfileXml.cs
@@ -355,6 +355,8 @@ namespace EduroamConfigure
 									new XElement(nsTTLS + "MSCHAPv2Authentication",
 										new XElement(nsTTLS + "UseWinlogonCredentials", "false")
 									),
+								/*
+								// Probably not in use anywhere
 								InnerAuthType.EAP_PEAP_MSCHAPv2 =>
 									CreateEapConfiguration(
 										eapType: EapType.PEAP,
@@ -364,7 +366,8 @@ namespace EduroamConfigure
 										serverNames: new List<string>(),
 										caThumbprints: new List<string>()
 									),
-								InnerAuthType.EAP_MSCHAPv2 =>
+								*/
+								InnerAuthType.EAP_MSCHAPv2 => // Sometimes just called TTLS-EAP
 									CreateEapConfiguration(
 										eapType:EapType.MSCHAPv2,
 										innerAuthType: InnerAuthType.None,
@@ -448,8 +451,8 @@ namespace EduroamConfigure
 				(EapType.TTLS, InnerAuthType.PAP) => true,
 				(EapType.TTLS, InnerAuthType.MSCHAP) => true,
 				(EapType.TTLS, InnerAuthType.MSCHAPv2) => true,
-				(EapType.TTLS, InnerAuthType.EAP_MSCHAPv2) => at_least_win10,
-				(EapType.TTLS, InnerAuthType.EAP_PEAP_MSCHAPv2) => at_least_win10,
+				(EapType.TTLS, InnerAuthType.EAP_MSCHAPv2) => at_least_win10, // Sometimes just called TTLS-EAP
+				//(EapType.TTLS, InnerAuthType.EAP_PEAP_MSCHAPv2) => at_least_win10, // theoretically supported, but we don't know any server
 				_ => false,
 			};
 		}

--- a/WpfApp/Menu/Login.xaml.cs
+++ b/WpfApp/Menu/Login.xaml.cs
@@ -185,18 +185,25 @@ namespace WpfApp.Menu
 			var brokenRules = IdentityProviderParser.GetRulesBrokenOnUsername(username, realm, hint).ToList();
 			bool usernameValid = !brokenRules.Any();
 
-			if (usernameValid && !String.IsNullOrEmpty(providedEapConfig.RequiredAnonymousIdentRealm))
+			if (usernameValid && providedEapConfig.RequiredAnonymousIdentRealm != null) // required realm can be empty string!
 			{
 				// Windows will set the realm itself for PEAP-EAP-MSCHAPv2
 				// If the realm does not match, AND ALL OTHER TESTS ARE OK (usernameValid == true),
 				// warn the user if the realms mismatch, but don't prevent connecting.
 
 				var fullUsername = GetFullUsername();
-				var userRealm = fullUsername.Substring(fullUsername.IndexOf("@"));
+				var userRealm = fullUsername.Contains("@")
+					? fullUsername.Substring(fullUsername.IndexOf("@"))
+					: ""
+					;
 
 				if (providedEapConfig.RequiredAnonymousIdentRealm != userRealm)
 				{
-					brokenRules.Add("/!\\ The outer realm will be set to \"" + userRealm + "\" but the profile specified \"" + providedEapConfig.RequiredAnonymousIdentRealm + "\"");
+					var strProfileRealm = String.IsNullOrEmpty(providedEapConfig.RequiredAnonymousIdentRealm)
+						? "realmless"
+						: "\"" + providedEapConfig.RequiredAnonymousIdentRealm + "\""
+						;
+					brokenRules.Add("/!\\ The realm for the OuterIdentity will be set to \"" + userRealm + "\" but the profile specified " + strProfileRealm);
 				}
 			}
 


### PR DESCRIPTION
@EdKingscote

> When an anonymous outer ID is configured on cat.eduroam.org I believe this tool extracts the value as-is (which includes the realm) and passes it straight through to the Windows profile for provisioning.
> 
> This results in configuration failing with an 1206/13 error - corrupted profile as Windows is not expecting to see @realm.tld appended to the value for the AnonymousUserName parameter. I tested this by manual crafting of an Microsoft XML profile, and this expectation/ behavior has also been confirmed by the community. (https://eduroam.slack.com/archives/C019BE46C94/p1654175069502989)
>
> 3.2.5.1 worked fine as it wasn't attempting to configure the anonymous outer ID for PEAP at all, but with  3.2.8 fixing this bug it breaks. Profiles from cat.eduroam.org without an anonymous ID work in both versions as expected.
>
> This is also being actively experienced in the field https://lists.geant.org/sympa/arc/geteduroam/2022-06/msg00001.html
