### PR TITLE
Remove code for running in background

### DIFF
--- a/WpfApp/Classes/SelfInstaller.cs
+++ b/WpfApp/Classes/SelfInstaller.cs
@@ -250,15 +250,6 @@ namespace WpfApp
 			lnk.WorkingDirectory = InstallDir;
 			lnk.Save();
 
-#if RUN_PERSISTENT
-			// Register the application to run on boot
-			Debug.WriteLine("Write str to {0}\\{1}: {2}",
-				rnsRun, ApplicationIdentifier, StartMinimizedCommand);
-			Registry.SetValue(rnsRun, ApplicationIdentifier, StartMinimizedCommand);
-			// TODO: test if run on boot works ^
-#endif
-
-
 			// Register scheduled task to check for updates
 			Debug.WriteLine("Create scheduled task: " + ScheduledTaskName);
 			using (var ts = new TaskService())
@@ -340,10 +331,6 @@ namespace WpfApp
 					exceptionOnNotExists: false);
 
 			// remove registry entries
-#if RUN_PERSISTENT
-			// Still gonna delete the Run registry key even if not being persistent,
-			// in case the older version did install it
-#endif
 			Debug.WriteLine("Delete registry value: " + rnsRun + "\\" + ApplicationIdentifier);
 			using (RegistryKey key = Registry.CurrentUser
 					.OpenSubKey("Software\\Microsoft\\Windows\\CurrentVersion\\Run", writable: true))
@@ -382,24 +369,5 @@ namespace WpfApp
 			return arg.Replace("%", "^%").Replace(" ", "^ ");
 		}
 
-#if RUN_PERSISTENT
-		public static void DelayedStart(string command, int delay = 5)
-		{
-			_ = command ?? throw new ArgumentNullException(paramName: nameof(command));
-
-			// TODO: escape the command. Escaping in CMD is not trivial
-			Debug.WriteLine("START: {0}", command, "");
-			Process.Start(new ProcessStartInfo
-				{
-					FileName = "cmd.exe",
-					Arguments = "/C choice /C Y /N /D Y /T " + ShellEscape(delay.ToString(CultureInfo.InvariantCulture)) +
-						" & " + command,
-					WindowStyle = ProcessWindowStyle.Hidden,
-					CreateNoWindow = true,
-					WorkingDirectory = "C:\\"
-				}
-			);
-		}
-#endif
 	}
 }

--- a/WpfApp/MainWindow.xaml
+++ b/WpfApp/MainWindow.xaml
@@ -23,20 +23,6 @@
             <RowDefinition Height="72"/>
         </Grid.RowDefinitions>
 
-        <tb:TaskbarIcon x:Name="TrayIcon"
-                ToolTipText="geteduroam"
-                TrayLeftMouseDown="tb_TrayLeftMouseDown"
-                TrayMouseDoubleClick="TrayIcon_TrayMouseDoubleClick"
-                Visibility="Hidden"
-                IconSource="geteduroam.ico">
-            <tb:TaskbarIcon.ContextMenu>
-                <ContextMenu>
-                    <MenuItem Header="Show geteduroam" Click="MenuItem_Click_Show"/>
-                    <MenuItem Header="Exit" Click="MenuItem_Click_Exit"/>
-                </ContextMenu>
-            </tb:TaskbarIcon.ContextMenu>
-        </tb:TaskbarIcon>
-
         <Grid x:Name="gridTopBar" Grid.RowSpan="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="45"/>

--- a/WpfApp/MainWindow.xaml.cs
+++ b/WpfApp/MainWindow.xaml.cs
@@ -16,9 +16,6 @@ using System.Windows.Navigation;
 using System.Xml;
 using WpfApp.Classes;
 using WpfApp.Menu;
-#if RUN_PERSISTENT
-using Hardcodet.Wpf.TaskbarNotification;
-#endif
 
 namespace WpfApp
 {
@@ -99,14 +96,6 @@ namespace WpfApp
 				lblVersion.Content = LetsWifi.VersionNumber;
 #endif
 			}
-
-#if RUN_PERSISTENT
-			if (App.StartHiddenInTray && App.Installer.IsRunningInInstallLocation)
-				Hide();
-
-			if (App.Installer.IsRunningInInstallLocation)
-				TrayIcon.Visibility = Visibility.Visible;
-#endif
 
 			Load();
 		}
@@ -508,15 +497,6 @@ namespace WpfApp
 
 		private static App App { get => (App)Application.Current; }
 
-#if RUN_PERSISTENT
-		public bool ShowNotification(string message, string title = "geteduroam", BalloonIcon icon = BalloonIcon.Info)
-		{
-			// TODO: doesn't show for peder, but does show for simon. RDP might be the culprit
-			TrayIcon.ShowBalloonTip(title, message, icon);
-			return true; // to be able to use it inside an expression
-		}
-#endif
-
 		/// <summary>
 		/// Called by the Menu.OAuthWait page when the OAuth process is done.
 		/// Gives the EapConfig it got from the oauth session as param
@@ -815,37 +795,6 @@ namespace WpfApp
 			Debug.WriteLine("{0}: {1}", nameof(IsShuttingDown), IsShuttingDown);
 			Debug.WriteLine("{0}: {1}", nameof(App.Installer.IsInstalled), App.Installer.IsInstalled);
 			Debug.WriteLine("{0}: {1}", nameof(App.Installer.IsRunningInInstallLocation), App.Installer.IsRunningInInstallLocation);
-
-#if RUN_PERSISTENT
-			if (!App.Installer.IsInstalled)
-				return; // do not cancel the Closing event
-
-			if (App.Installer.IsInstalled && !App.Installer.IsRunningInInstallLocation)
-			{
-#if !DEBUG
-				// this happens after the first time setup
-				SelfInstaller.DelayedStart(App.Installer.StartMinimizedCommand);
-#endif
-				return; // do not cancel the Closing event
-			}
-
-			if (IsShuttingDown)
-				return; // closed in tray icon, unable to cancel. avoid creating the balloon
-
-			// Cancels the Window.Close(), but unable to cancel Application.Shutdown()
-			e.Cancel = true;
-
-			ShowNotification("geteduroam is still running in the background");
-
-			Hide(); // window
-
-			if (PersistingStore.IdentityProvider != null)
-				LoadPageInstalledProfile();
-			else
-				LoadPageMainMenu();
-
-			historyFormId.Clear();
-#endif
 		}
 
 		private void TrayIcon_TrayMouseDoubleClick(object sender, RoutedEventArgs e)

--- a/WpfApp/WpfApp.csproj
+++ b/WpfApp/WpfApp.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <DefineConstants>RUN_PERSISTENT</DefineConstants>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{88939F1B-5677-49B1-BC07-71605598494A}</ProjectGuid>
@@ -40,7 +39,6 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <!-- <DefineConstants>DEBUG;TRACE;RUN_PERSISTENT</DefineConstants> -->
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -253,9 +251,6 @@
   <ItemGroup>
     <PackageReference Include="Costura.Fody">
       <Version>4.1.0</Version>
-    </PackageReference>
-    <PackageReference Include="Hardcodet.NotifyIcon.Wpf">
-      <Version>1.0.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
       <Version>5.0.3</Version>


### PR DESCRIPTION
The app has code for running in the background, but it's not being used. The reason for this was that the app could install a new profile when needed, but this can also be accomplished by scheduled tasks.

Must users will probably not need a tray icon. Removing the dependency saves a few 100K from the compiled binary.