### PR TITLE
Update ProfileXml.cs

### DIFF
--- a/EduroamConfigure/ProfileXml.cs
+++ b/EduroamConfigure/ProfileXml.cs
@@ -279,7 +279,7 @@ namespace EduroamConfigure
 
 				// Windows wants to add the realm itself, we must only set the local part
 				// This appears to be the case for PEAP-EAP-MSCHAPv2
-				string anonymousUserName = outerIdentity.Contains("@")
+				string anonymousUserName = !String.IsNullOrEmpty(outerIdentity) && outerIdentity.Contains("@")
 					? outerIdentity.Substring(0, outerIdentity.IndexOf("@"))
 					: outerIdentity
 					;


### PR DESCRIPTION
Check if outerIdentity is null. An exception occurs if outerIdentity is null or empty. Fix for:
Win11 22H2 (22621.608) - ok
Win11 21H2 (22000.978) - ok
Win10 21H2 (19044.1645) - ok